### PR TITLE
restart showSelectedOnly flag after triggered resetSelectedPhotosHandler

### DIFF
--- a/src/containers/Gallery/Gallery.js
+++ b/src/containers/Gallery/Gallery.js
@@ -61,7 +61,8 @@ class Gallery extends Component {
     this.setState({
       ...this.state,
       allPhotos: updatedPhotos,
-      selectedPhotosCounter: 0
+      selectedPhotosCounter: 0,
+      showSelectedOnly: false
     });
   };
 


### PR DESCRIPTION
po resecie proponuję, by zrestartować flagę showSelectedOnly